### PR TITLE
Auditing Fields 작성

### DIFF
--- a/simple-community/src/main/java/com/project/simplecommunity/config/JpaConfig.java
+++ b/simple-community/src/main/java/com/project/simplecommunity/config/JpaConfig.java
@@ -21,7 +21,8 @@ public class JpaConfig {
                 .map(SecurityContext::getAuthentication)
                 .filter(Authentication::isAuthenticated)
                 .map(Authentication::getPrincipal)
+                .filter(principal -> principal instanceof UserPrincipal)
                 .map(UserPrincipal.class::cast)
-                .map(UserPrincipal::getUsername);
+                .map(UserPrincipal::username);
     }
 }

--- a/simple-community/src/main/java/com/project/simplecommunity/domain/AuditingFields.java
+++ b/simple-community/src/main/java/com/project/simplecommunity/domain/AuditingFields.java
@@ -5,13 +5,8 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDateTime;
 
 @Getter
 @EntityListeners(AuditingEntityListener.class)


### PR DESCRIPTION
# 수정한 파일
- JpaConfig
- AuditingFields
# 변경된 사항
- JpaConfig
  - 이전 코드는 sessionId(cookie)가 존재하지 않으면 `Authentication::getPrincipal`이 `"Anonymous"`를 리턴해서 `UserPrincipal.class::cast`에서 문제가 발생했었다
  - 현재 코드는 `"Anonymous"`가 리턴되면 `null`을 담고 있는 `UserPrincipal`을 반환해 예외 발생을 회피함
- AuditingFields
  - import optimize
## 관련 이슈
- This closes #3 