### PR TITLE
Response Wrapper 클래스 작성

### DIFF
--- a/simple-community/src/main/java/com/project/simplecommunity/dto/response/wrapper/PageInfo.java
+++ b/simple-community/src/main/java/com/project/simplecommunity/dto/response/wrapper/PageInfo.java
@@ -1,0 +1,23 @@
+package com.project.simplecommunity.dto.response.wrapper;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+public class PageInfo {
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+
+    private PageInfo(Page page) {
+        this.page = page.getNumber() + 1;
+        this.size = page.getSize();
+        this.totalElements = page.getTotalElements();
+        this.totalPages = page.getTotalPages();
+    }
+
+    public static PageInfo of(Page page) {
+        return new PageInfo(page);
+    }
+}

--- a/simple-community/src/main/java/com/project/simplecommunity/dto/response/wrapper/PageResponseDto.java
+++ b/simple-community/src/main/java/com/project/simplecommunity/dto/response/wrapper/PageResponseDto.java
@@ -1,0 +1,17 @@
+package com.project.simplecommunity.dto.response.wrapper;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class PageResponseDto<T> {
+    private List<T> data;
+    private PageInfo pageInfo;
+
+    public PageResponseDto(List<T> data, Page page) {
+        this.data = data;
+        this.pageInfo = PageInfo.of(page);
+    }
+}

--- a/simple-community/src/main/java/com/project/simplecommunity/dto/response/wrapper/SingleResponseDto.java
+++ b/simple-community/src/main/java/com/project/simplecommunity/dto/response/wrapper/SingleResponseDto.java
@@ -1,0 +1,11 @@
+package com.project.simplecommunity.dto.response.wrapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SingleResponseDto<T> {
+    private T data;
+}
+


### PR DESCRIPTION
# 작성한 파일
- SingleResponseDto
- PageResponseDto
- PageInfo
# 변경된 사항
- 이제 Controller에서 반환하는 response body는 모두 wrapper class로 감싸서 반환해야함
- 페이지, 단일 응답 데이터 모두 같은 경로로 참고할 수 있게 통일
## 관련이슈
- This cloese #11 